### PR TITLE
add a newline after each line from stdin

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ fn read_stdin() -> () {
             paint(rng.gen(), rng.gen(), rng.gen());
             print!("{}", c);
         }
+        println!();
     }
 }
 


### PR DESCRIPTION
Now when acat reads from stdin automatically adds a newline (removed by the lines() method ) at the end of each line.